### PR TITLE
Use react as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,9 @@
   ],
   "author": "Niklas Kraßnig",
   "license": "ISC",
-  "dependencies": {
-    "react": "^17.0.2"
-  },
   "devDependencies": {
+    
+    "react": "^17.0.2",
     "@types/react": "^17.0.3",
     "typescript": "^5.1.6"
   }


### PR DESCRIPTION
If a developer uses this library from npm. It can cause trouble while running because it recognizes two copies of react in the same app(if the dependant app has also react as dependency)
![React Error](https://github.com/Krassnig/use-destructuring/assets/16473991/e885507f-ffe6-4ceb-a605-b824f51a9c9e)
